### PR TITLE
notebook with *flat* training selection in apparent mag

### DIFF
--- a/notebooks/protoDC2v5_uniform_training_selection.ipynb
+++ b/notebooks/protoDC2v5_uniform_training_selection.ipynb
@@ -1,0 +1,699 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import scipy.interpolate \n",
+    "import pandas as pd\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up the paths to the protoDC2v5 data and read the hdf5 file into a pandas dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = \"/global/projecta/projectdirs/lsst/groups/PZ/PhotoZDC2/protoDC2v5\"\n",
+    "#path = \"/global/u2/s/schmidt9/PZDC2/pz_pdf/notebooks\"\n",
+    "infile = \"protodc2_v5_ugrizy_witherrs.h5\"\n",
+    "#infile = \"protodc2_v5_ugrizy_witherrs_training.h5\" #this one for just the ~400k training galaxies\n",
+    "fullpath = os.path.join(path,infile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_hdf(fullpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>LSST_filters/magnitude:LSST_u:observed:dustAtlas</th>\n",
+       "      <th>LSST_filters/magnitude:LSST_g:observed:dustAtlas</th>\n",
+       "      <th>LSST_filters/magnitude:LSST_r:observed:dustAtlas</th>\n",
+       "      <th>LSST_filters/magnitude:LSST_i:observed:dustAtlas</th>\n",
+       "      <th>LSST_filters/magnitude:LSST_z:observed:dustAtlas</th>\n",
+       "      <th>LSST_filters/magnitude:LSST_y:observed:dustAtlas</th>\n",
+       "      <th>redshift</th>\n",
+       "      <th>ra</th>\n",
+       "      <th>dec</th>\n",
+       "      <th>galaxyID</th>\n",
+       "      <th>...</th>\n",
+       "      <th>scaterr_g</th>\n",
+       "      <th>scatmag_r</th>\n",
+       "      <th>scaterr_r</th>\n",
+       "      <th>scatmag_i</th>\n",
+       "      <th>scaterr_i</th>\n",
+       "      <th>scatmag_z</th>\n",
+       "      <th>scaterr_z</th>\n",
+       "      <th>scatmag_y</th>\n",
+       "      <th>scaterr_y</th>\n",
+       "      <th>training_flag</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>21.234911</td>\n",
+       "      <td>20.090427</td>\n",
+       "      <td>19.677958</td>\n",
+       "      <td>19.508871</td>\n",
+       "      <td>19.484373</td>\n",
+       "      <td>19.435213</td>\n",
+       "      <td>0.024627</td>\n",
+       "      <td>-0.213268</td>\n",
+       "      <td>-1.780913</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.005042</td>\n",
+       "      <td>19.682526</td>\n",
+       "      <td>0.005018</td>\n",
+       "      <td>19.511381</td>\n",
+       "      <td>0.005024</td>\n",
+       "      <td>19.489855</td>\n",
+       "      <td>0.005056</td>\n",
+       "      <td>19.441219</td>\n",
+       "      <td>0.005206</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>21.839048</td>\n",
+       "      <td>20.748993</td>\n",
+       "      <td>20.418985</td>\n",
+       "      <td>20.241453</td>\n",
+       "      <td>20.190296</td>\n",
+       "      <td>20.152172</td>\n",
+       "      <td>0.024598</td>\n",
+       "      <td>-1.293915</td>\n",
+       "      <td>-2.062044</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.005106</td>\n",
+       "      <td>20.422693</td>\n",
+       "      <td>0.005048</td>\n",
+       "      <td>20.244062</td>\n",
+       "      <td>0.005066</td>\n",
+       "      <td>20.176054</td>\n",
+       "      <td>0.005158</td>\n",
+       "      <td>20.159077</td>\n",
+       "      <td>0.005648</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>21.023718</td>\n",
+       "      <td>20.142702</td>\n",
+       "      <td>19.991816</td>\n",
+       "      <td>19.915903</td>\n",
+       "      <td>19.910103</td>\n",
+       "      <td>19.878025</td>\n",
+       "      <td>0.024227</td>\n",
+       "      <td>0.681523</td>\n",
+       "      <td>-1.484340</td>\n",
+       "      <td>2</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.005046</td>\n",
+       "      <td>20.002113</td>\n",
+       "      <td>0.005027</td>\n",
+       "      <td>19.907297</td>\n",
+       "      <td>0.005041</td>\n",
+       "      <td>19.912237</td>\n",
+       "      <td>0.005105</td>\n",
+       "      <td>19.876188</td>\n",
+       "      <td>0.005412</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>17.604139</td>\n",
+       "      <td>16.012825</td>\n",
+       "      <td>15.264262</td>\n",
+       "      <td>14.847938</td>\n",
+       "      <td>14.583278</td>\n",
+       "      <td>14.419316</td>\n",
+       "      <td>0.024483</td>\n",
+       "      <td>-0.304187</td>\n",
+       "      <td>-0.923260</td>\n",
+       "      <td>3</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.005001</td>\n",
+       "      <td>15.266548</td>\n",
+       "      <td>0.005000</td>\n",
+       "      <td>14.850696</td>\n",
+       "      <td>0.005000</td>\n",
+       "      <td>14.585126</td>\n",
+       "      <td>0.005000</td>\n",
+       "      <td>14.416851</td>\n",
+       "      <td>0.005001</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>19.315104</td>\n",
+       "      <td>18.073452</td>\n",
+       "      <td>17.455185</td>\n",
+       "      <td>17.079489</td>\n",
+       "      <td>16.859879</td>\n",
+       "      <td>16.746384</td>\n",
+       "      <td>0.024451</td>\n",
+       "      <td>-0.261973</td>\n",
+       "      <td>-0.874825</td>\n",
+       "      <td>4</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.005004</td>\n",
+       "      <td>17.459517</td>\n",
+       "      <td>0.005001</td>\n",
+       "      <td>17.078701</td>\n",
+       "      <td>0.005002</td>\n",
+       "      <td>16.857254</td>\n",
+       "      <td>0.005002</td>\n",
+       "      <td>16.738359</td>\n",
+       "      <td>0.005006</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 23 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   LSST_filters/magnitude:LSST_u:observed:dustAtlas  \\\n",
+       "0                                         21.234911   \n",
+       "1                                         21.839048   \n",
+       "2                                         21.023718   \n",
+       "3                                         17.604139   \n",
+       "4                                         19.315104   \n",
+       "\n",
+       "   LSST_filters/magnitude:LSST_g:observed:dustAtlas  \\\n",
+       "0                                         20.090427   \n",
+       "1                                         20.748993   \n",
+       "2                                         20.142702   \n",
+       "3                                         16.012825   \n",
+       "4                                         18.073452   \n",
+       "\n",
+       "   LSST_filters/magnitude:LSST_r:observed:dustAtlas  \\\n",
+       "0                                         19.677958   \n",
+       "1                                         20.418985   \n",
+       "2                                         19.991816   \n",
+       "3                                         15.264262   \n",
+       "4                                         17.455185   \n",
+       "\n",
+       "   LSST_filters/magnitude:LSST_i:observed:dustAtlas  \\\n",
+       "0                                         19.508871   \n",
+       "1                                         20.241453   \n",
+       "2                                         19.915903   \n",
+       "3                                         14.847938   \n",
+       "4                                         17.079489   \n",
+       "\n",
+       "   LSST_filters/magnitude:LSST_z:observed:dustAtlas  \\\n",
+       "0                                         19.484373   \n",
+       "1                                         20.190296   \n",
+       "2                                         19.910103   \n",
+       "3                                         14.583278   \n",
+       "4                                         16.859879   \n",
+       "\n",
+       "   LSST_filters/magnitude:LSST_y:observed:dustAtlas  redshift        ra  \\\n",
+       "0                                         19.435213  0.024627 -0.213268   \n",
+       "1                                         20.152172  0.024598 -1.293915   \n",
+       "2                                         19.878025  0.024227  0.681523   \n",
+       "3                                         14.419316  0.024483 -0.304187   \n",
+       "4                                         16.746384  0.024451 -0.261973   \n",
+       "\n",
+       "        dec  galaxyID      ...        scaterr_g  scatmag_r  scaterr_r  \\\n",
+       "0 -1.780913         0      ...         0.005042  19.682526   0.005018   \n",
+       "1 -2.062044         1      ...         0.005106  20.422693   0.005048   \n",
+       "2 -1.484340         2      ...         0.005046  20.002113   0.005027   \n",
+       "3 -0.923260         3      ...         0.005001  15.266548   0.005000   \n",
+       "4 -0.874825         4      ...         0.005004  17.459517   0.005001   \n",
+       "\n",
+       "   scatmag_i  scaterr_i  scatmag_z  scaterr_z  scatmag_y  scaterr_y  \\\n",
+       "0  19.511381   0.005024  19.489855   0.005056  19.441219   0.005206   \n",
+       "1  20.244062   0.005066  20.176054   0.005158  20.159077   0.005648   \n",
+       "2  19.907297   0.005041  19.912237   0.005105  19.876188   0.005412   \n",
+       "3  14.850696   0.005000  14.585126   0.005000  14.416851   0.005001   \n",
+       "4  17.078701   0.005002  16.857254   0.005002  16.738359   0.005006   \n",
+       "\n",
+       "   training_flag  \n",
+       "0          False  \n",
+       "1          False  \n",
+       "2          False  \n",
+       "3          False  \n",
+       "4          False  \n",
+       "\n",
+       "[5 rows x 23 columns]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 18286706 entries, 0 to 18286705\n",
+      "Data columns (total 23 columns):\n",
+      "LSST_filters/magnitude:LSST_u:observed:dustAtlas    float32\n",
+      "LSST_filters/magnitude:LSST_g:observed:dustAtlas    float32\n",
+      "LSST_filters/magnitude:LSST_r:observed:dustAtlas    float32\n",
+      "LSST_filters/magnitude:LSST_i:observed:dustAtlas    float32\n",
+      "LSST_filters/magnitude:LSST_z:observed:dustAtlas    float32\n",
+      "LSST_filters/magnitude:LSST_y:observed:dustAtlas    float32\n",
+      "redshift                                            float64\n",
+      "ra                                                  float32\n",
+      "dec                                                 float32\n",
+      "galaxyID                                            int64\n",
+      "scatmag_u                                           float32\n",
+      "scaterr_u                                           float32\n",
+      "scatmag_g                                           float32\n",
+      "scaterr_g                                           float32\n",
+      "scatmag_r                                           float32\n",
+      "scaterr_r                                           float32\n",
+      "scatmag_i                                           float32\n",
+      "scaterr_i                                           float32\n",
+      "scatmag_z                                           float32\n",
+      "scaterr_z                                           float32\n",
+      "scatmag_y                                           float32\n",
+      "scaterr_y                                           float32\n",
+      "training_flag                                       bool\n",
+      "dtypes: bool(1), float32(20), float64(1), int64(1)\n",
+      "memory usage: 1.8 GB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot a histogram of the apparent magnitude number counts.  We want to select a flat/Uniform set of galaxies in terms of apparent i-band magnitude.  The total number of galaxies that we want in the training sample is defined as N_tot.  We will also define the number of bins and the range over which we want to calculate the histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_tot = 105000\n",
+    "N_bins = 20\n",
+    "i_min = 18.\n",
+    "i_max = 25."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtwAAAKvCAYAAABZHxgGAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAIABJREFUeJzt3X+wZ/V93/fX26ytaGxLBmlNKaAuragziBnLgUF0kkldMwaaZIw6FRo8SbSpGZEUktqZdNwlaUsrDTNikka1MhUtsaiQqhoRxR6RECJvkVO3MwGxUnAwSAwbSwxs+BUWizgZyQN+9497trp72R93Yd/7vXf9eMx853u+n+85536+R3fgydH5nlvdHQAAYMb3rXoCAABwOhPcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADNqx6gmcbO985zt7165dq54GAACnua9+9av/qrt3Hm+90y64d+3alX379q16GgAAnOaq6qnNrOeSEgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBg0I5VTwAAgO1v1577Vvazv/WxP72yn70ZznADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAw6LjBXVU/VlWPrHu8UlW/UFVnVdXeqnpyeT5z3TY3V9X+qnqiqq5aN35JVT26vPeJqqpl/C1V9fll/KGq2rVum93Lz3iyqnaf3I8PAACzjhvc3f1Ed7+3u9+b5JIk/zbJryXZk+SB7r4wyQPL61TVRUmuS/KeJFcn+WRVnbHs7vYkH05y4fK4ehm/PsnL3f3uJB9Pctuyr7OS3JLkfUkuS3LL+rAHAICt7kQvKbkiyb/o7qeSXJPkrmX8riTvX5avSXJ3d3+3u7+ZZH+Sy6rqnCRv6+4Hu7uTfGbDNof29YUkVyxnv69Ksre7D3b3y0n25nuRDgAAW96JBvd1SX5lWT67u59dlp9LcvayfG6Sp9dt88wydu6yvHH8sG26+9Uk307yjmPs6zBVdUNV7auqfS+++OIJfiQAAJiz6eCuqh9I8jNJ/t7G95Yz1n0S53VCuvuO7r60uy/duXPnqqYBAACvcyJnuP/TJF/r7ueX188vl4lkeX5hGT+Q5Px12523jB1YljeOH7ZNVe1I8vYkLx1jXwAAsC2cSHD/bL53OUmS3Jvk0F1Ddif54rrx65Y7j1yQtS9HfmW5/OSVqrp8uT77Qxu2ObSvDyT58nLW/EtJrqyqM5cvS165jAEAwLawYzMrVdUPJvnpJH9x3fDHktxTVdcneSrJB5Okux+rqnuSPJ7k1SQ3dfdryzY3Jvl0krcmuX95JMmnkny2qvYnOZi1a8XT3Qer6qNJHl7W+0h3H3wDnxMAAFZiU8Hd3f8ma19iXD/2UtbuWnKk9W9NcusRxvclufgI499Jcu1R9nVnkjs3M08AANhq/KVJAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGDQpoK7qn6kqr5QVd+oqq9X1X9UVWdV1d6qenJ5PnPd+jdX1f6qeqKqrlo3fklVPbq894mqqmX8LVX1+WX8oaratW6b3cvPeLKqdp+8jw4AAPM2e4b7l5L84+7+o0l+PMnXk+xJ8kB3X5jkgeV1quqiJNcleU+Sq5N8sqrOWPZze5IPJ7lweVy9jF+f5OXufneSjye5bdnXWUluSfK+JJcluWV92AMAwFZ33OCuqrcn+ZNJPpUk3f373f27Sa5Jctey2l1J3r8sX5Pk7u7+bnd/M8n+JJdV1TlJ3tbdD3Z3J/nMhm0O7esLSa5Yzn5flWRvdx/s7peT7M33Ih0AALa8zZzhviDJi0n+96r6Z1X1y1X1g0nO7u5nl3WeS3L2snxukqfXbf/MMnbusrxx/LBtuvvVJN9O8o5j7OswVXVDVe2rqn0vvvjiJj4SAACcGpsJ7h1J/liS27v7J5L8myyXjxyynLHukz+9zenuO7r70u6+dOfOnauaBgAAvM5mgvuZJM9090PL6y9kLcCfXy4TyfL8wvL+gSTnr9v+vGXswLK8cfywbapqR5K3J3npGPsCAIBt4bjB3d3PJXm6qn5sGboiyeNJ7k1y6K4hu5N8cVm+N8l1y51HLsjalyO/slx+8kpVXb5cn/2hDdsc2tcHknx5OWv+pSRXVtWZy5clr1zGAABgW9ixyfX+SpLPVdUPJPmdJP9F1mL9nqq6PslTST6YJN39WFXdk7UofzXJTd392rKfG5N8Oslbk9y/PJK1L2R+tqr2JzmYtbucpLsPVtVHkzy8rPeR7j74Bj8rAACccpsK7u5+JMmlR3jriqOsf2uSW48wvi/JxUcY/06Sa4+yrzuT3LmZeQIAwFbjL00CAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADNqx6gkAAHDy7Npz36qnwAbOcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwKBNBXdVfauqHq2qR6pq3zJ2VlXtraonl+cz161/c1Xtr6onquqqdeOXLPvZX1WfqKpaxt9SVZ9fxh+qql3rttm9/Iwnq2r3yfrgAABwKpzIGe7/pLvf292XLq/3JHmguy9M8sDyOlV1UZLrkrwnydVJPllVZyzb3J7kw0kuXB5XL+PXJ3m5u9+d5ONJblv2dVaSW5K8L8llSW5ZH/YAALDVvZlLSq5JcteyfFeS968bv7u7v9vd30yyP8llVXVOkrd194Pd3Uk+s2GbQ/v6QpIrlrPfVyXZ290Hu/vlJHvzvUgHAIAtb7PB3Un+r6r6alXdsIyd3d3PLsvPJTl7WT43ydPrtn1mGTt3Wd44ftg23f1qkm8neccx9gUAANvCjk2u9ye6+0BV/WiSvVX1jfVvdndXVZ/86W3O8h8BNyTJu971rlVNAwAAXmdTZ7i7+8Dy/EKSX8va9dTPL5eJZHl+YVn9QJLz121+3jJ2YFneOH7YNlW1I8nbk7x0jH1tnN8d3X1pd1+6c+fOzXwkAAA4JY4b3FX1g1X1w4eWk1yZ5LeT3Jvk0F1Ddif54rJ8b5LrljuPXJC1L0d+Zbn85JWquny5PvtDG7Y5tK8PJPnycp33l5JcWVVnLl+WvHIZAwCAbWEzl5ScneTXljv47Ujyf3b3P66qh5PcU1XXJ3kqyQeTpLsfq6p7kjye5NUkN3X3a8u+bkzy6SRvTXL/8kiSTyX5bFXtT3Iwa3c5SXcfrKqPJnl4We8j3X3wTXxeAAA4pY4b3N39O0l+/AjjLyW54ijb3Jrk1iOM70ty8RHGv5Pk2qPs684kdx5vngAAsBX5S5MAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBox6onAABwutm1575VT4EtxBluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABm06uKvqjKr6Z1X1D5fXZ1XV3qp6cnk+c926N1fV/qp6oqquWjd+SVU9urz3iaqqZfwtVfX5Zfyhqtq1bpvdy894sqp2n4wPDQAAp8qJnOH++SRfX/d6T5IHuvvCJA8sr1NVFyW5Lsl7klyd5JNVdcayze1JPpzkwuVx9TJ+fZKXu/vdST6e5LZlX2cluSXJ+5JcluSW9WEPAABb3aaCu6rOS/Knk/zyuuFrkty1LN+V5P3rxu/u7u929zeT7E9yWVWdk+Rt3f1gd3eSz2zY5tC+vpDkiuXs91VJ9nb3we5+OcnefC/SAQBgy9vsGe7/OckvJvmDdWNnd/ezy/JzSc5els9N8vS69Z5Zxs5dljeOH7ZNd7+a5NtJ3nGMfQEAwLZw3OCuqj+T5IXu/urR1lnOWPfJnNiJqKobqmpfVe178cUXVzUNAAB4nc2c4f7jSX6mqr6V5O4kP1VV/0eS55fLRLI8v7CsfyDJ+eu2P28ZO7Asbxw/bJuq2pHk7UleOsa+DtPdd3T3pd196c6dOzfxkQAA4NQ4bnB3983dfV5378ralyG/3N1/Lsm9SQ7dNWR3ki8uy/cmuW6588gFWfty5FeWy09eqarLl+uzP7Rhm0P7+sDyMzrJl5JcWVVnLl+WvHIZAwCAbWHHm9j2Y0nuqarrkzyV5INJ0t2PVdU9SR5P8mqSm7r7tWWbG5N8Oslbk9y/PJLkU0k+W1X7kxzMWtinuw9W1UeTPLys95HuPvgm5gwAAKfUCQV3d/+TJP9kWX4pyRVHWe/WJLceYXxfkouPMP6dJNceZV93JrnzROYJAABbhb80CQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAg3asegIAAFN27blv1VMAZ7gBAGCS4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYdNzgrqo/UlVfqarfqqrHqup/XMbPqqq9VfXk8nzmum1urqr9VfVEVV21bvySqnp0ee8TVVXL+Fuq6vPL+ENVtWvdNruXn/FkVe0+mR8eAACmbeYM93eT/FR3/3iS9ya5uqouT7InyQPdfWGSB5bXqaqLklyX5D1Jrk7yyao6Y9nX7Uk+nOTC5XH1Mn59kpe7+91JPp7ktmVfZyW5Jcn7klyW5Jb1YQ8AAFvdcYO71/ze8vL7l0cnuSbJXcv4XUnevyxfk+Tu7v5ud38zyf4kl1XVOUne1t0Pdncn+cyGbQ7t6wtJrljOfl+VZG93H+zul5PszfciHQAAtrxNXcNdVWdU1SNJXshaAD+U5OzufnZZ5bkkZy/L5yZ5et3mzyxj5y7LG8cP26a7X03y7STvOMa+AABgW9hUcHf3a9393iTnZe1s9cUb3u+snfVeiaq6oar2VdW+F198cVXTAACA1zmhu5R09+8m+Y2sXdbx/HKZSJbnF5bVDiQ5f91m5y1jB5bljeOHbVNVO5K8PclLx9jXxnnd0d2XdvelO3fuPJGPBAAAozZzl5KdVfUjy/Jbk/x0km8kuTfJobuG7E7yxWX53iTXLXceuSBrX478ynL5yStVdflyffaHNmxzaF8fSPLl5az5l5JcWVVnLl+WvHIZAwCAbWHHJtY5J8ldy51Gvi/JPd39D6vqnya5p6quT/JUkg8mSXc/VlX3JHk8yatJburu15Z93Zjk00nemuT+5ZEkn0ry2aran+Rg1u5yku4+WFUfTfLwst5Huvvgm/nAAABwKh03uLv7nyf5iSOMv5TkiqNsc2uSW48wvi/JxUcY/06Sa4+yrzuT3Hm8eQIAwFbkL00CAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwSHADAMAgwQ0AAIMENwAADBLcAAAwaMeqJwAAnN527blv1VOAlXKGGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABh03uKvq/Kr6jap6vKoeq6qfX8bPqqq9VfXk8nzmum1urqr9VfVEVV21bvySqnp0ee8TVVXL+Fuq6vPL+ENVtWvdNruXn/FkVe0+mR8eAACmbeYM96tJ/lp3X5Tk8iQ3VdVFSfYkeaC7L0zywPI6y3vXJXlPkquTfLKqzlj2dXuSDye5cHlcvYxfn+Tl7n53ko8nuW3Z11lJbknyviSXJbllfdgDAMBWd9zg7u5nu/try/K/TvL1JOcmuSbJXctqdyV5/7J8TZK7u/u73f3NJPuTXFZV5yR5W3c/2N2d5DMbtjm0ry8kuWI5+31Vkr3dfbC7X06yN9+LdAAA2PJO6Bru5VKPn0jyUJKzu/vZ5a3nkpy9LJ+b5Ol1mz2zjJ27LG8cP2yb7n41ybeTvOMY+wIAgG1h08FdVT+U5O8n+YXufmX9e8sZ6z7Jc9u0qrqhqvZV1b4XX3xxVdMAAIDX2VRwV9X3Zy22P9fdv7oMP79cJpLl+YVl/ECS89dtft4ydmBZ3jh+2DZVtSPJ25O8dIx9Haa77+juS7v70p07d27mIwEAwCmxmbuUVJJPJfl6d//tdW/dm+TQXUN2J/niuvHrljuPXJC1L0d+Zbn85JWqunzZ54c2bHNoXx9I8uXlrPmXklxZVWcuX5a8chkDAIBtYccm1vnjSf58kker6pFl7K8n+ViSe6rq+iRPJflgknT3Y1V1T5LHs3aHk5u6+7VluxuTfDrJW5PcvzyStaD/bFXtT3Iwa3c5SXcfrKqPJnl4We8j3X3wDX5WAAA45Y4b3N39/yapo7x9xVG2uTXJrUcY35fk4iOMfyfJtUfZ151J7jzePAEAYCvylyYBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGDQZm4LCACcBnbtuW/VU4A/lJzhBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQTtWPQEA+MNm1577Vj0F4BRyhhsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBgkOAGAIBBghsAAAYJbgAAGCS4AQBg0I5VTwAAVmHXnvtWPQXgDwlnuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQYIbAAAGCW4AABgkuAEAYJDgBgCAQccN7qq6s6peqKrfXjd2VlXtraonl+cz1713c1Xtr6onquqqdeOXVNWjy3ufqKpaxt9SVZ9fxh+qql3rttm9/Iwnq2r3yfrQAABwqmzmDPenk1y9YWxPkge6+8IkDyyvU1UXJbkuyXuWbT5ZVWcs29ye5MNJLlweh/Z5fZKXu/vdST6e5LZlX2cluSXJ+5JcluSW9WEPAADbwXGDu7t/M8nBDcPXJLlrWb4ryfvXjd/d3d/t7m8m2Z/ksqo6J8nbuvvB7u4kn9mwzaF9fSHJFcvZ76uS7O3ug939cpK9eX34AwDAlvZGr+E+u7ufXZafS3L2snxukqfXrffMMnbusrxx/LBtuvvVJN9O8o5j7AsAALaNHW92B93dVdUnYzJvVFXdkOSGJHnXu961yqkAcIJ27blv1VMAGPVGz3A/v1wmkuX5hWX8QJLz16133jJ2YFneOH7YNlW1I8nbk7x0jH29Tnff0d2XdvelO3fufIMfCQAATr43Gtz3Jjl015DdSb64bvy65c4jF2Tty5FfWS4/eaWqLl+uz/7Qhm0O7esDSb68XOf9pSRXVtWZy5clr1zGAABg2zjuJSVV9StJfjLJO6vqmazdOeRjSe6pquuTPJXkg0nS3Y9V1T1JHk/yapKbuvu1ZVc3Zu2OJ29Ncv/ySJJPJflsVe3P2pczr1v2dbCqPprk4WW9j3T3xi9vAgDAlnbc4O7unz3KW1ccZf1bk9x6hPF9SS4+wvh3klx7lH3dmeTO480RAAC2Kn9pEgAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEE7Vj0BAFZv1577Vj0FgNOWM9wAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwKAdq54AAN+za899q54CACeZM9wAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAM2rHqCQBsNbv23LfqKQBwGnGGGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGDQjlVPAOBodu25b9VTAIA3zRluAAAYJLgBAGCQ4AYAgEGCGwAABgluAAAYJLgBAGCQ4AYAgEGCGwAABvnDN8Bx+QM0APDGOcMNAACDBDcAAAwS3AAAMEhwAwDAIMENAACD3KUEtgl3CgGA7ckZbgAAGCS4AQBgkOAGAIBBghsAAAb50iScIF9eBABOhDPcAAAwSHADAMAgl5SwLbmsAwDYLpzhBgCAQc5w86Y40wwAcGzbIrir6uokv5TkjCS/3N0fW/GUthTRCwCwdW354K6qM5L8L0l+OskzSR6uqnu7+/HVzuz1hC8AABtth2u4L0uyv7t/p7t/P8ndSa5Z8ZwAAGBTtkNwn5vk6XWvn1nGAABgy9vyl5RsRlXdkOSG5eXvVdUTK5rKO5P8qxX97NOdYzvHsZ3j2M5xbOc4tnMc2yF128qO7b+3mZW2Q3AfSHL+utfnLWP/v+6+I8kdp3JSR1JV+7r70lXP43Tk2M5xbOc4tnMc2zmO7RzHds5WP7bb4ZKSh5NcWFUXVNUPJLkuyb0rnhMAAGzKlj/D3d2vVtVfTvKlrN0W8M7ufmzF0wIAgE3Z8sGdJN39j5L8o1XPYxNWflnLacyxnePYznFs5zi2cxzbOY7tnC19bKu7Vz0HAAA4bW2Ha7gBAGDbEtxvUFXdWVUvVNVvrxt7b1U9WFV0AkPmAAAEzElEQVSPVNW+qrpslXPcro5ybH+8qv5pVT1aVf+gqt62yjluR1V1flX9RlU9XlWPVdXPL+NnVdXeqnpyeT5z1XPdbo5xbK9dXv9BVW3Zb89vZcc4tn+zqr5RVf+8qn6tqn5k1XPdbo5xbD+6HNdHqurXq+rfXfVct5ujHdt17/+1quqqeueq5rhdHeP39n+oqgPL7+0jVfWnVj3X9VxS8gZV1Z9M8ntJPtPdFy9jv57k4919//I/9C9290+ucJrb0lGO7cNJ/uvu/r+r6ueSXNDd/90q57ndVNU5Sc7p7q9V1Q8n+WqS9yf5C0kOdvfHqmpPkjO7+79Z4VS3nWMc207yB0n+t6z9/u5b4TS3pWMc2/OSfHn5Yv1tSeL39sQc49g+092vLOv8V0ku6u6/tMKpbjtHO7bd/XhVnZ/kl5P80SSXdLf7cp+AY/zefjDJ73X331rpBI/CGe43qLt/M8nBjcNJDp15fXuSf3lKJ3WaOMqx/Q+T/OayvDfJf35KJ3Ua6O5nu/try/K/TvL1rP3V1muS3LWsdlfW/sHFCTjase3ur3f3qv4Q12nhGMf217v71WW1B7MW4JyAYxzbV9at9oNZ+3cbJ+AY/7xNko8n+cU4rm/IcY7tliW4T65fSPI3q+rpJH8ryc0rns/p5LGshWGSXJvD/xgSJ6iqdiX5iSQPJTm7u59d3nouydkrmtZpYcOx5SQ6xrH9uST3n+r5nE42HtuqunX5d9mfTfLfr25m29/6Y1tV1yQ50N2/tdJJnSaO8M+Ev7JcDnXnVrs8UnCfXP9lkr/a3ecn+atJPrXi+ZxOfi7JjVX11SQ/nOT3VzyfbauqfijJ30/yCxvOZKXXrjFz1uUNOtax5c052rGtqr+R5NUkn1vV3La7Ix3b7v4by7/LPpfkL69yftvZ+mObtd/Tvx7/AXNSHOH39vYk/36S9yZ5Nsn/tMLpvY7gPrl2J/nVZfnvJfGlyZOku7/R3Vd29yVJfiXJv1j1nLajqvr+rP0D6nPdfeh39fnlmrhD18a9sKr5bWdHObacBEc7tlX1F5L8mSR/tn0h6Q3ZxO/t5+ISvjfkCMf2P0hyQZLfqqpvZe0yqK9V1b+zulluT0f6ve3u57v7te7+gyR/N1uswQT3yfUvk/zHy/JPJXlyhXM5rVTVjy7P35fkv03yv652RttPVVXW/l+Xr3f331731r1Z+4/FLM9fPNVz2+6OcWx5k452bKvq6qxdB/sz3f1vVzW/7ewYx/bCdatdk+Qbp3pu292Rjm13P9rdP9rdu7p7V5Jnkvyx7n5uhVPddo7xe3vOutX+syS/vXHbVXKXkjeoqn4lyU8meWeS55PckuSJJL+Utb/g+Z0kN3b3V1c1x+3qKMf2h5LctKzyq0ludkbrxFTVn0jy/yR5NGt3zkjW/u/Nh5Lck+RdSZ5K8sHu3vilVY7hGMf2LUn+TpKdSX43ySPdfdVKJrlNHePYfiJrx/elZexBd9I4Mcc4ttcn+bFl7Kkkf6m7D6xkktvU0Y7t8pezD63zrSSXukvJiTnG7+3PZu1ykk7yrSR/cd33k1ZOcAMAwCCXlAAAwCDBDQAAgwQ3AAAMEtwAADBIcAMAwCDBDQAAgwQ3AAAMEtwAADDo/wOIaXr0fwr1igAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x2b10b906c320>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = plt.figure(figsize=(12,12))\n",
+    "hist_n, binedges, hist_patches = plt.hist(df['scatmag_i'],bins=N_bins,range=(i_min,i_max))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[   2893.    4076.    5844.    8241.   11637.   16955.   24502.   34385.\n",
+      "   48011.   63370.   80726.  100368.  121577.  149520.  188045.  243211.\n",
+      "  319277.  419505.  548529.  714757.] [ 18.    18.35  18.7   19.05  19.4   19.75  20.1   20.45  20.8   21.15\n",
+      "  21.5   21.85  22.2   22.55  22.9   23.25  23.6   23.95  24.3   24.65  25.  ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print (hist_n,binedges)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to get a uniform number per magnitude slice we can just make a random number between 0 and 1 for each galaxy and weight by the inverse of the number counts histogram.  If we then use this weight as a threshold, we will select the same number of galaxies per magnitude bin.  num_per_bin will be the number selected per bin, the total desired divided by the number of bins.."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5250.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "inv_n = 1./hist_n\n",
+    "num_per_bin = N_tot/N_bins\n",
+    "print (num_per_bin)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 1.8147252   1.28802748  0.89835729  0.63705861  0.4511472   0.30964317\n",
+      "  0.21426822  0.15268286  0.10934994  0.08284677  0.06503481  0.05230751\n",
+      "  0.04318251  0.03511236  0.02791885  0.02158619  0.0164434   0.01251475\n",
+      "  0.00957105  0.00734515]\n"
+     ]
+    }
+   ],
+   "source": [
+    "weight = num_per_bin/hist_n\n",
+    "print (weight)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the weight is >1 for the first two bins, and thus *all* galaxies in those bins will be selected, while in the final bin between 24.64 and 25. the weight is only 0.00734, so less than 1percent of those galaxies will be selected for the training set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 18.    18.35  18.7   19.05  19.4   19.75  20.1   20.45  20.8   21.15\n",
+      "  21.5   21.85  22.2   22.55  22.9   23.25  23.6   23.95  24.3   24.65  25.  ]\n",
+      "[ 18.175  18.525  18.875  19.225  19.575  19.925  20.275  20.625  20.975\n",
+      "  21.325  21.675  22.025  22.375  22.725  23.075  23.425  23.775  24.125\n",
+      "  24.475  24.825]\n"
+     ]
+    }
+   ],
+   "source": [
+    "bincents = 0.5*(binedges[1:]+binedges[:-1])\n",
+    "print(binedges)\n",
+    "print(bincents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a 1d interpolation function with linear interpolation to define the weight threshold continuously as a function of i-band magnitude.  Set the weigt to just return the boundary values below and above the defined bin boundaries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weightFunc = scipy.interpolate.interp1d(bincents,weight,kind='linear',bounds_error=False,fill_value=(weight[0],weight[-1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "randoms = np.random.rand(len(df['scatmag_i']))\n",
+    "allweights = weightFunc(df['scatmag_i'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_train_mask = np.logical_and(randoms<allweights,df['scatmag_i']<25.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "107327\n"
+     ]
+    }
+   ],
+   "source": [
+    "print (np.sum(flat_train_mask))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_col_name = 'flat_training_flag'\n",
+    "df[train_col_name]=flat_train_mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_train_i = df['scatmag_i'][flat_train_mask]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a plot of the number counts for the full sample and those selected in the training set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x2b10b93fa7f0>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtwAAALCCAYAAADtdQSCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAIABJREFUeJzt3X2UZWdd5+3vT5rQCKHCqxCSmKynNRIgRNOECKOCUUGwYWQARRxEGxsUBaJI0OAQhWcGhQEB4wM9Jk+JIyBG3poJb46ASCBUIgkSIsJgoh0NCZEUxCQGzD1/nNNlUenuVHWfu/epU9e1Vq/u2nvXOb+qvarz6Z377FOttQAAAH1809ADAADALBPcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADraNPQAk3ave92rHXvssUOPAQDAjLv44ou/1Fq79+0dN3PBfeyxx+aiiy4aegwAAGZcVV25muMsKQEAgI4ENwAAdCS4AQCgI8ENAAAdzdyLJvfla1/7Wnbv3p2bb7556FFYYfPmzTnqqKNyxzvecehRAAAmbsME9+7du3P44Yfn2GOPTVUNPQ5jrbVcd9112b17d4477rihxwEAmLgNs6Tk5ptvzj3veU+xPWWqKve85z39nwcAYGZtmOBOIranlPMCAMyyDRXcAABwqG2YNdwrbZ9f6PK45zzjoas+9stf/nKOPPLI7NixI695zWuSJGeddVZuuOGGvPKVr8z8/Hze/e5357zzzusyKwAA/bnCPaA3velNOfXUU/PmN785t9xyy9DjAADQgeAe0LnnnpsXv/jFOfHEE/POd75z6HEAAOhAcA/kU5/6VK677rp8//d/f376p38655577tAjAQDQgeAeyDnnnJOnP/3pqao88YlPzIUXXpirrrpq6LEAAJiwDfuiySHdcsstedOb3pQ73elOeeMb35hk9E6Y8/Pzww4GAMDEucI9gHe+8505/vjjs3v37lxxxRW54oor8v73v19wAwDMoA17hXstt++btHPPPTdPe9rTvmHbd3/3d+fWW2/Nhz/84Zx88skDTQYAwKRVa23oGSaiqrYl2bZly5af/dznPneb/Zdffnke8IAHHPrBWBXnBwBYb6rq4tba1ts7bmaWlLTWdrXWdszNzQ09CgAALJmZ4AYAgGkkuAEAoCPBDQAAHQluAADoSHADAEBHG/Y+3HnTj/V53J/441Ud9o53vCO/+qu/ms2bN+ctb3lLvuM7viNf/epXc9e73nWfn3P99ddn586deeELX7jX/XveQGfHjh0HNPrrX//63HTTTTn99NP3e9y73vWufOQjH8krXvGKA3oeAICNxBXugbzhDW/Ib/7mb+aTn/xkjj/++FV9zvXXX5/f/u3f3uf+K664Ijt37tzn/q9//ev7ffxnP/vZtxvbSfL4xz9ebAMArJLgHsDpp5+ej3zkIznjjDPyqEc96jb7X/CCF+ShD31oHvKQh+S0007LlVdemSR5znOek+uvvz4nnXRSHv7wh9/m857znOfkM5/5TE466aQ86UlPSpIce+yxedGLXpRTTjklz3rWs3L11VfnUY96VE4++eQ88IEP/Iar5WeddVZe8IIXJEnm5+fzQz/0Q/mxH/uxPPCBD8wjHvGIXH311Uv79jz+hz70oZx00kl51rOelRNPPDEPechDcvnlly895plnnpktW7bkYQ97WM4444xs3Xq794YHAJgpgnsAr371q7N169a89rWvzQc/+MHb7H/Ri16UhYWFXHrppXnqU5+aM844I0ly9tln54gjjsgll1ySCy644Dafd/bZZ+eEE07IJZdckvPOO29p+1e+8pV84hOfyDnnnJMjjjgiu3btysUXX5xLLrkkF110Ud773vfudc6FhYW88pWvzGWXXZYTTjghr3vd6/Z63GWXXZZnP/vZ+dSnPpWnPOUpednLXpYk2bVrV9797nfn0ksvzcc+9rHs7R1AAQBm3cZdwz3F3vOe9+Tss8/ODTfccLvLQFbj6U9/+tKf/+3f/i2/8iu/kgsuuCCttVx99dW55JJL8pjHPOY2n/eIRzwiRx99dJLk1FNPzQc+8IG9Pv7xxx+f7/zO71w6bteuXUmSD37wg3nKU56Su9zlLkmSn/qpn8pLX/rSg/56AGC92T6/MJHHOecZD53I43BoCe4pc+WVV+b000/PwsJCjjvuuFxwwQX5iZ/4iYN6zOUvxHzVq16VL3/5y7nwwguzefPm7NixIzfffPNeP2/z5s1Lf77DHe6wz/hf7XEAABuRJSVT5itf+UoOO+yw3Pe+982tt96a17/+9Uv77na3u+XGG2/cZ9De7W53y+Li4n4f//rrr8/97ne/bN68OVdddVXe+c53TnT+5R75yEfmvPPOy4033phbb701f/iHf9jtuQAAppXgnjIPfvCD8+QnPzknnHBCHvawh+W4445b2nePe9wjT3va0/LgBz94ry+aPPHEE3P88cfnQQ960NKLGld67nOfm49+9KN50IMelO3bt+e0007r9rU8/vGPz6Mf/eiceOKJOfXUU3PkkUdmbm6u2/MBAEyjaq0NPcNEbd26tV100UW32X755ZfnAQ94wAATbWxf/epXc/jhh+fWW2/NM5/5zBx55JFLL6pczvkBYJZNag33JFgHPjlVdXFr7XZvwWYNN109/elPzxVXXJGbbropJ5988j7ftAcAptU0xTLrk+Cmq7e//e1DjwAAMChruAEAoKMNFdyztl59VjgvAMAs2zDBvXnz5lx33XXibsq01nLdddd9w728AQBmyYZZw33UUUdl9+7dufbaa4cehRU2b96co446augxAAC62DDBfcc73vEb7mkNAACHwoZZUgIAAEMQ3AAA0JHgBgCAjgQ3AAB0JLgBAKCjDXOXEgBgY9k+vzD0CFNpEt+Xc57x0AlMsnG4wg0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICONg09AADAStvnF4YeASbGFW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCP34QYAYE0mdZ/0c57x0Ik8zrRzhRsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB1N9W0Bq+qbkrw0yd2SXNRa+4OBRwIAgDU55Fe4q+rcqrqmqj69YvtjquqzVfX5qnrRePMTkhyV5GtJdh/qWQEA4GANsaRkPsljlm+oqjskOTvJDyc5IclTq+qEJMcnuaC19ktJfu4QzwkAAAftkC8paa39RVUdu2LzKUk+31r7QpJU1Vsyurr9D0luGR9z66GaEQA4cJN6F0KYFdPyosn7ZxTXe+web3tbkkdX1euSfHhfn1xVO6rqoqq66Nprr+07KQAArMFUv2iytXZjku2rOG5nkp1JsnXr1tZ7LgAAWK1pucJ9VZKjl3181HgbAACsa9MS3AtJvq2qjquqw5L8eJJ3DTwTAAActCFuC/jmJB9LcnxV7a6q7a21ryf5hSTvS3J5kre21i471LMBAMCkDXGXkqfuY/v5Sc4/xOMAAEBX07KkBAAAZpLgBgCAjgQ3AAB0JLgBAKCjmQnuqtpWVTsXFxeHHgUAAJbMTHC31na11nbMzc0NPQoAACyZmeAGAIBpJLgBAKAjwQ0AAB0JbgAA6EhwAwBAR5uGHgAAmA7b5xeGHgFmkivcAADQkSvcAAAMYhL/V+WcZzx0ApP0NTNXuL3TJAAA02hmgts7TQIAMI1mJrgBAGAaCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoaGaCu6q2VdXOxcXFoUcBAIAlMxPcrbVdrbUdc3NzQ48CAABLZia4AQBgGgluAADoaNPQAwAAB2/7/MLQIwD74Ao3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdDQzwV1V26pq5+Li4tCjAADAkpkJ7tbartbajrm5uaFHAQCAJTMT3AAAMI0ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQ0aahBwCAjW77/MLQIwAducINAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQ0cwEd1Vtq6qdi4uLQ48CAABLZia4W2u7Wms75ubmhh4FAACWzExwAwDANBLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjjYNPQAArFfb5xeGHgFYB1zhBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBARzMT3FW1rap2Li4uDj0KAAAsmZngbq3taq3tmJubG3oUAABYMjPBDQAA00hwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEebhh4AAIawfX5h6BGADcIVbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQ0cwEd1Vtq6qdi4uLQ48CAABLZia4W2u7Wms75ubmhh4FAACWzExwAwDANBLcAADQkeAGAICOBDcAAHQkuAEAoKNNQw8AAGuxfX5h6BEA1sQVbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADraNPQAAGwc2+cXhh4B4JBzhRsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6mpngrqptVbVzcXFx6FEAAGDJzAR3a21Xa23H3Nzc0KMAAMCSmQluAACYRoIbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOho09ADALA+bJ9fGHoEgHXJFW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6GjT0AMA0Nf2+YWhRwDY0FzhBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOto09AAA7Nv2+YWhRwDgILnCDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6murgrqpHVtVHqur1VfXIoecBAIC1OuTBXVXnVtU1VfXpFdsfU1WfrarPV9WLxptbkhuSbE6y+1DPCgAAB2vTAM85n+R3k7xxz4aqukOSs5P8YEZhvVBV70rykdbah6vqW5K8KsnTDv24AGu3fX5h6BEAmBKH/Ap3a+0vkvzzis2nJPl8a+0LrbVbkrwlyRNaa7eO9385yZ0O4ZgAADARQ1zh3pv7J/mHZR/vTvKwqnpikkcnOSKjq+J7VVU7kuxIkmOOOabjmAAAsDbTEtx71Vp7W5K3reK4nUl2JsnWrVtb77kAAGC1puUuJVclOXrZx0eNtwEAwLo2LcG9kOTbquq4qjosyY8nedfAMwEAwEEb4raAb07ysSTHV9XuqtreWvt6kl9I8r4klyd5a2vtskM9GwAATNohX8PdWnvqPrafn+T8QzwOAAB0NS1LSgAAYCYJbgAA6EhwAwBAR4IbAAA6mpngrqptVbVzcXFx6FEAAGDJzAR3a21Xa23H3Nzc0KMAAMCSqX5rd4AhbJ9fGHoEAGbIqq9wV9WdqurMqnpIz4EAAGCWrDq4W2v/muTMJEf0GwcAAGbLWtdwX5jku3oMAgAAs2ita7hfmORNVfW1jN6G/YtJ2vIDWms3Tmg2AABY99Ya3BeOf39tktfs45g7HPg4AAAwW9Ya3D+TFVe0AQCAfVtTcLfW5jvNAQAAM+mA3vimqk6oqv9cVb9WVfcdb9tSVYdPdrw1zeSdJgEAmDprCu6qumtVvTXJp5P8fpKXJjlyvPu/JnnJZMdbPe80CQDANFrrFe5XJXl4ktOSHJ6klu07P8ljJjQXAADMhLW+aPKJSZ7XWvtgVa28G8mVSb51MmMBAMBsWOsV7jsnuW4f+w5P8m8HNw4AAMyWtQb3QpKn72Pfk5JccHDjAADAbFnrkpJfT/KBqvqzJH+S0T25H1tVp2cU3N874fkAAGBdW+t9uD9SVacleXmS383oRZO/keTjSX6gtbYw+REBVm/7vL+GAJgua73CndbaR5N8T1XdOcndk1zfWrtx4pMBAMAMOKA3vhm7OcnXktw0oVkAAGDmrDm4q+qxVXVBRsF9dZKbq+qCqnrcxKcDAIB1bq3vNPmsJLuS3JDkeUmePP79hiTvGu8HAADG1rqG+9eSvKG19vMrtr++ql6f5Mwkb5jIZGtUVduSbNuyZcsQTw8AAHu11iUl90zy9n3s+9Mk9zi4cQ5ca21Xa23H3NzcUCMAAMBtrDW4P5jk+/ax7/uS/MXBjQMAALPldpeUVNUJyz58bZLfr6p7JnlHkmuS3CfJjyb54STP7DEkAACsV6tZw/3pjN5Rco9K8qzxrzb+eI/3JrnDxKYDAIB1bjXB/ajuUwAAwIy63eBurX34UAwCAACzaM1v7b5HVW1KctjK7d7mHQAA/t1a3/hmrqp+r6r+KaN3mvzqXn4BAABja73CPZ/R7f/+R5LPJ7ll0gMBAMAsWWtwn5bkWa21N/cYBgAAZs1a3/jm75NYow0AAKu01ivcL0zyG1X1ydba3/cYCNiYts8vDD0CAHSxpuBurZ1fVT+Q5PNVdUWS6/dyzCkTmg0AANa9NQV3Vb0yyfOTLGTKXjRZVduSbNuyZcvQowAAwJK1Lil5ZpIzW2v/rccwB6O1tivJrq1bt/7s0LMAAMAea33R5I1JLu4xCAAAzKK1BvdrkuyoquoxDAAAzJq1Lim5V5KHJflsVX0ot33RZGutnTGJwQAAYBasNbiflOTrSe6Y5Af3sr8lEdwAADC21tsCHtdrEAAAmEVrXcMNAACswVrvw/3zt3dMa+33DnwcAACYLWtdw/27+9nXxr8LbgAAGFvTkpLW2jet/JXkHkmemuTSJCf0GBIAANartV7hvo3W2vVJ/riq5pK8IckjD/YxAQBgVkzyRZN/l2TrBB8PAADWvYkEd1XdL8kvZxTdAADA2FrvUnJt/v3FkXscluTwJDcneeKE5gIAgJmw1jXcZ+e2wX1zkt1J3ttau24iUwEAwIxY6ztNntVpjoNWVduSbNuyZcvQo8CGs31+YegRAGBq3W5wV9Wfr+HxWmvttIOY54C11nYl2bV169afHeL5AQBgb1ZzhXs1y0Tul+Thue1yEwAA2NBuN7hba0/e176qOibJGUl+JMmXkrx6cqMBAMD6d0BvfFNVW5L8apKfTHLN+M9vaK3dNMHZAABg3VvrbQEfmOTMJE9O8g9Jnpfk3NbaLR1mAwCAdW9Vb3xTVSdX1duSfCrJdyV5ZpJva629XmwDAMC+reYuJe9J8kNJ/jrJj7fW/qT7VAAAMCNWs6Tk0ePfj0pydlWdvb+DW2v3OeipAABgRqwmuH+j+xQAADCjVnNbQMENAAAHaFUvmgQAAA6M4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQ0Wre2n1dqKptSbZt2bJl6FFg3dg+vzD0CAAw82bmCndrbVdrbcfc3NzQowAAwJKZCW4AAJhGghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoKNNQw8AHJjt8wtDjwAArIIr3AAA0NHMBHdVbauqnYuLi0OPAgAAS2YmuFtru1prO+bm5oYeBQAAlsxMcAMAwDQS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHS0aegBYCPaPr8w9AgAwCHiCjcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBARzMT3FW1rap2Li4uDj0KAAAsmZngbq3taq3tmJubG3oUAABYMjPBDQAA00hwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEebhh4A1pPt8wtDjwAArDOucAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOto09ABwqGyfXxh6BABgA3KFGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANDR1Ad3Vd2lqi6qqh8ZehYAAFirQx7cVXVuVV1TVZ9esf0xVfXZqvp8Vb1o2a4zkrz10E4JAACTMcQV7vkkj1m+oarukOTsJD+c5IQkT62qE6rqB5N8Jsk1h3pIAACYhE2H+glba39RVceu2HxKks+31r6QJFX1liRPSHLXJHfJKMJvqqrzW2u3rnzMqtqRZEeSHHPMMf2GBwCANTrkwb0P90/yD8s+3p3kYa21X0iSqnpGki/tLbaTpLW2M8nOJNm6dWvrOyoAAKzetAT3frXW5oeeAQAADsS03KXkqiRHL/v4qPE2AABY16YluBeSfFtVHVdVhyX58STvGngmAAA4aId8SUlVvTnJI5Pcq6p2J3lJa+2cqvqFJO9Lcock57bWLjvUszGdts8vDD0CAMABG+IuJU/dx/bzk5x/iMcBAICupmVJCQAAzCTBDQAAHQluAADoaGaCu6q2VdXOxcXFoUcBAIAlMxPcrbVdrbUdc3NzQ48CAABLZia4AQBgGgluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKCjmQlu7zQJAMA0mpng9k6TAABMo5kJbgAAmEaCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADraNPQAk1JV25Js27Jly9CjsMz2+YWhRwAAGNTMXOFure1qre2Ym5sbehQAAFgyM8ENAADTSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANDRzAR3VW2rqp2Li4tDjwIAAEtmJrhba7taazvm5uaGHgUAAJbMTHADAMA0EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEebhh6A6bV9fmHoEQAA1j1XuAEAoCPBDQAAHQluAADoSHADAEBHghsAADqameCuqm1VtXNxcXHoUQAAYMnMBHdrbVdrbcfc3NzQowAAwJKZCW4AAJhGghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR5uGHgAA1uIXv/jiiTzO677lZRN5HIDbI7jZMCbxH2n/gd67SQXQJEzLORKFAOwhuOlK5O6d70s/0xT/00L8Tz9/J8BsE9zsk3CZbs7PxjBr59nXA2xEgpupN03/QZumWYCD4+cZOFQENwCrIlABDozgnkHb5xcm8ji/OJFHAQDY2AT3DHIVCgBgenjjGwAA6GhmgruqtlXVzsXFxaFHAQCAJTMT3K21Xa21HXNzc0OPAgAAS2YmuAEAYBoJbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0tGnoAfhGl/zWo4ceAQCACZqZK9xVta2qdi4uLg49CgAALJmZ4G6t7Wqt7Zibmxt6FAAAWDIzwQ0AANNIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI42DT0AAHDwfvGLLz7ox3jdt7xsApMAKwnuCbnktx499AgAAEwhS0oAAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhoZoK7qrZV1c7FxcWhRwEAgCUzE9yttV2ttR1zc3NDjwIAAEtmJrgBAGAaCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKCjaq0NPcNEVdW1Sa4c4KnvleRLAzwvh5bzvDE4zxuD8zz7nOONYcjz/K2ttXvf3kEzF9xDqaqLWmtbh56DvpznjcF53hic59nnHG8M6+E8W1ICAAAdCW4AAOhIcE/OzqEH4JBwnjcG53ljcJ5nn3O8MUz9ebaGGwAAOnKFGwAAOhLcB6Cqzq2qa6rq08sy1HO6AAAKgUlEQVS2nVRVH6+qS6rqoqo6ZcgZOXhVdXRVfbCqPlNVl1XV88bb71FVH6iqz41/v/vQs3Jg9nOOX1FVf1NVn6qqt1fVEUPPyoHb13letv+Xq6pV1b2GmpGDt7/zXFW/OP6ZvqyqfnvIOTk4+/l7e6o7zJKSA1BV35vkhiRvbK09aLzt/Ule3Vp7T1U9NskLW2uPHHBMDlJV3S/J/Vprf1VVhye5OMl/TPKMJP/cWnt5Vb0oyd1ba2cMOCoHaD/n+Kgkf95a+3pV/VaSOMfr177Oc2vtM1V1dJLfT/IdSU5urbln8zq1n5/nb0lyZpLHtdb+taru01q7ZshZOXD7Oc+/kynuMFe4D0Br7S+S/PPKzUnuNv7zXJJ/PKRDMXGttX9qrf3V+M9fTXJ5kvsneUKSPxgf9gcZ/aCzDu3rHLfW3t9a+/r4sI9nFOCsU/v5WU6SVyd5YUZ/h7OO7ec8/1ySl7fW/nW8T2yvY/s5z1PdYZuGHmCGPD/J+6rqlRn9Q+bhA8/DBFXVsUm+M8mFSb6ltfZP411XZ3T1hHVuxTle7meS/PGhnoc+lp/nqnpCkqtaa5dW1aBzMVkrfp5fkeR7qur/TXJzkhe01haGm45JWXGep7rDXOGenJ9Lcnpr7egkpyc5Z+B5mJCqumuSP03y/NbaV5bva6M1Wa6MrXP7OsdVdWaSryf5o6FmY3KWn+eMzuuvJfkvgw7FxO3l53lTknskOTXJryR5a/kX1rq3l/M81R0muCfnp5K8bfznP0kyVYv1OTBVdceMfqD/qLW25/x+cbyGbM9aMv97ch3bxzlOVT0jyY8keVrzYpd1by/n+f9JclySS6vqioyWDf1VVd13uCk5WPv4ed6d5G1t5BNJbk3iBbLr2D7O81R3mOCenH9M8n3jP39/ks8NOAsTML4Cck6Sy1trr1q2610Z/WBn/Ps7D/VsTMa+znFVPSajdb2Pb63dONR8TMbeznNr7a9ba/dprR3bWjs2oyj7rtba1QOOykHYz9/Z70jyqPEx357ksCReHLtO7ec8T3WHuUvJAaiqNyd5ZEb/Qv5ikpck+WyS12T0v65uTvLzrbWLh5qRg1dV/yHJR5L8dUZXRJLR/4K+MMlbkxyT5MokT2mtrXwRLevAfs7xa5PcKcl1420fb609+9BPyCTs6zy31s5fdswVSba6S8n6tZ+f5z9Lcm6Sk5LcktEa7j8fZEgO2n7O81cyxR0muAEAoCNLSgAAoCPBDQAAHQluAADoSHADAEBHghsAADoS3MCGVlXzVXXRKo67YvyWwYOqqi9V1VlDzzEpK7+vVfWU8ZsOTfI5Lqqq+Uk+JsBabBp6AICBvTTJnYceYgP70fz7/c6T5CkZvcfB/CDTAHQguIENrbX2f4aeYSNrrX1y6BkAerOkBNjQVrukZNnxv15VV1fVDVX1R1U1t2zfXarqd6vqs1V1Y1X9XVWdXVV3W/EYraqeV1X/taquraprxsfdacVx31tVl1bVzVV1cVU9fJUztqo6var+e1VdN16G8oLxvp+qqi9U1fVVdW5VbV72efcbb/tCVd1UVX9bVS+rqsNWPP4xVfWe8TF/V1XPqKrzqupDy445a/y831lVHx9/Pz5ZVd+z4rGWlpSMl338pyTfN/4a2p7lM3tb0jN+3lZVd1227UFV9dHx9+zyqnr8Pr5H31NVHx7PdV1V/Y+qOnw131+AtXKFG2D1nprk80l+Nsn9kvx2kt9P8uTx/m9Ocsck/yXJ1UmOTnJmkj9J8ugVj/XLSf48yU8mOTHJf0ty5fgxU1VHJnlPkk8keVKSI5P80fg5VuOXk/yv8cw/kuQVVXWfJA9N8twkxyR5dZK/TfLy8efcK8n1SX4lyZeSfHuSs5LcO8mzxnNVknclOSLJz2T0Fsq/Pj5m5f8t+OYkfzB+nquTvCTJ26rqW1trN+5l5peO5zoiyc+Pt+1e5debqrpzkveNZ/+JjJYK/U6Suyb59LLjHpHR232/I6Pv7T3H34O7jz8GmCjBDbB6d07yuNbaDUlSVf+S5A+r6gGttctba9dmHKbj/ZuS/F2Sv6yqY1prf7/ssa5orT1j/Of3jSPwiRkHd5LnZxSzj9sTp+Pn+5+rnPVzrbU9kfxnGf2j4GeTfGtr7Svj7Y/MaA31y5OktfbXSX5p2fwfTfIvSc6tql9srd2S5LFJHpLklNbawvi4TyS5IrcN7jsneX5r7c/Hx/1Tkk8m+d4k7105cGvt/1TVPyf5ptbax1f5dS7300nuk+RhrbXd4+e8Islfrjju5UkuaK392LKv9aok/7uqHtRa+3QAJsiSEoBlqmrT8l8rdn9gT2yPvT1JZXTVeM/n/+fx0okbknwt/x57377isd6/4uPPJDlq2cenjJ9v+ZXgt6/hS/nfe/7QWrs1o/C/eE9sj30+yf2XzV5V9fyq+kxV3TSe/4+S3CmjK8/J6Gu9ek9sjx//qiQX72WGW5J8aNnHnxn/ftRtD52IUzL6GpeuirfWPprkmj0fV9U3J/nuJG9dcZ7/MqOv9+ROswEbmOAG+EZfW/FruWuWfzCO4RsyWl6SqvrRJG9M8rGMriifmtEV5CTZnG90/YqPb1lxzH3383yrsbfHv73nfH6SV2YU9k/IKGCfM96357j7Jrl2L8+3t21fHcd+kmR8hXz5Y03abb5nY8u33T3JHZL8Xr7xPP9rRsuBju40G7CBWVIC8I0eup9991n+wfhq6V2T/NN405OTXNha+/llx3zfAc5x9X6er5cnJzmvtXbmsuc8YS9z3Xsvn3vvjJbA9HJzksNWbLv7io+vTvIde/nc5d/H65O0jNamn7+XY//xAOcD2CdXuAGWaa1dtPzXit0/uPyOGBldvW5J9hx354yulC73tAMcZWH8fMtfJPmj+zp4QlYz/0KS+1bVKXs2VNX9M7mlGCuvuu+xO8kDVmz7ob3MdnJVLS1ZGa+NXwru1tq/JPl4kuNXnuvxL8ENTJwr3ACrd1OS/1VVr8hoGckrkry9tbZnbfIHkpxdVWcmuTCjFxiedoDP9TsZLed4d1W9KqO7lPzqeIZePpDkuVV1YUYvgHxaki0rjjk/yaUZrYHeM89Lknwxya05eH+T5AlV9R8ziux/HEfw25O8rqp+LaOw/k9JHrjic///JC/O6BydldE/IF6a0V1LlnthRi+QvDXJeUm+mtEa9cclObO19rcT+DoAlrjCDbB6b0nywSTnZBTE70myfdn+NyT570mel+RtSb41o9vTrdn4hYiPzehWfX+a0W3yfjLJ3m6nNym/meTNSV42/v2WjG4huHyultH67r/JKHBfk+T/y+gFkctfkHmgfi+jF5Sem1FY7xhv35nR9/y5Sd6a0ZX4l62Y7caMbr/4Lxmdq5dkdHvEK1cc95cZ3Snl3kn+MMmujCL8HzL6hwPARNXo704AODA1evOfLyT53dbaS4aeB2DaWFICwJpU1bMzWj7yuYyuEv9SRrcOPHfIuQCmleAGYK1uTnJGRktmWkbvhvkDrbUr9/tZABuUJSUAANCRF00CAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKCj/wuhA0z9K1HWFgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x2b10b93f5780>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = plt.figure(figsize=(12,12))\n",
+    "nall,binedgeall,pathesall = plt.hist(df['scatmag_i'],bins=35,range=(18.,28.),alpha=0.7,label='All')\n",
+    "ntrain, binedgestrain, patchestrain = plt.hist(flat_train_i,bins=35,range=(18.,28.),alpha=0.7,label='flat training')\n",
+    "plt.yscale('log')\n",
+    "plt.xlabel('i-band magnitude',fontsize=15)\n",
+    "plt.ylabel('Number',fontsize=15)\n",
+    "plt.legend(loc='upper left',fontsize=11)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, make a plot of the redshift distribution of the full sample as well as the flat training sample"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_train_sz = df['redshift'][flat_train_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x2b10bb90e3c8>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtwAAAJVCAYAAADtFiJ5AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAIABJREFUeJzt3X+UZ3V95/nXWxDbUSwUjDE2BGbaaW0USCiB6MxGgmPA2daMB3+gswQHbVl/hGWGCFndHYzOzk7i6EQlg72hT485R4hxVOgs/shMVMhgSMMGEWQdUSE2OwgiFCTAIOnP/lHVlbLptqu66lPfb916PM7p03zv99atd3Ntz7Mun++91VoLAADQxxNGPQAAAAyZ4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQ0YGjHmCpHXbYYe3II48c9RgAAAzcDTfc8IPW2jP3td/ggvvII4/M9ddfP+oxAAAYuKq6Yz77WVICAAAdCW4AAOhIcAMAQEeCGwAAOhrchyb35kc/+lF27NiRRx55ZNSjsJs1a9Zk7dq1eeITnzjqUQAAltyqCe4dO3bk4IMPzpFHHpmqGvU4zGit5d57782OHTty1FFHjXocAIAlt2qWlDzyyCM59NBDxfaYqaoceuih/ssDADBYqya4k4jtMeW8AABDtmqWlOzu7K3buxz30rNe1OW4AACsTIO5wl1VG6tq89TU1KhHmbf77rsvT37yk3PuuefObrvoooty/vnnJ0m2bt2a008/fVTjAQCwBAYT3K21ba21TRMTE6MeZd4+8YlP5KSTTspll12WRx99dNTjAADQwWCCeyXasmVL3vOe9+SYY47JFVdcMepxAADoQHCPyE033ZR77703v/RLv5Q3velN2bJly6hHAgCgA8E9IpdeemnOPPPMVFVe/epX57rrrsudd9456rEAAFhiq/YuJaP06KOP5hOf+ESe9KQn5eMf/3iS6Sdhbt26dbSDAQCw5FzhHoErrrgi69evz44dO3L77bfn9ttvzxe/+EXBDQAwQKv2Cvco75e9ZcuWvPGNb/yxbb/wC7+QnTt35itf+UqOP/74EU0GAMBSW7XBPUqf+9zn9rj929/+9o+9Puuss3LWWWctw0QAAPRiSQkAAHQkuAEAoCPBDQAAHQluAADoSHADAEBH7lICAMCyOXvr9iU93ihv9Txfqze4P/G6Psd9wx/Ma7fPfvaz+Y3f+I2sWbMml19+eZ73vOflwQcfzFOf+tS9fs3999+fzZs3513vetce39/1AJ1Nmzbt1+iXXHJJHn744Zx33nk/cb8rr7wy11xzTX77t397v74PAMBqYknJiHzsYx/Lb/7mb+Yv/uIvsn79+nl9zf3335/f+q3f2uv7t99+ezZv3rzX9x977LGfePxzzjlnn7GdJK985SvFNgDAPAnuETjvvPNyzTXX5IILLsjJJ5/8uPfPP//8vOhFL8qxxx6bU045JXfccUeS5O1vf3vuv//+HHfccXnxi1/8uK97+9vfnm984xs57rjjcvrppydJjjzyyFx44YU54YQT8ta3vjV33XVXTj755Bx//PE5+uijf+xq+UUXXZTzzz8/SbJ169a8/OUvz+te97ocffTReclLXpK77rpr9r1dx//yl7+c4447Lm9961tzzDHH5Nhjj82tt946e8x3v/vdWbduXU488cRccMEFmZycXKJ/iwAAK4PgHoEPfehDmZyczIc//OF86Utfetz7F154YbZv356vfe1rOeOMM3LBBRckSS6++OIccsghufHGG3Pttdc+7usuvvjibNiwITfeeGM+9alPzW5/4IEH8ud//ue59NJLc8ghh2Tbtm254YYbcuONN+b666/P5z//+T3OuX379nzgAx/ILbfckg0bNuQjH/nIHve75ZZbcs455+Smm27Ka1/72rz//e9Pkmzbti1/9Ed/lK997Wv56le/mm9961sL/ncFALDSCe4x9LnPfS4nnXRSXvCCF+QDH/hAbrzxxkUd78wzz5z957/5m7/Jr//6r+fYY4/N8ccfn5tvvnmvx3/JS16Sww8/PEly0kknPe7R87usX78+P/dzP/e4/b70pS/lta99bZ7ylKfkCU94Qn71V391UX8OAICVaPV+aHJM3XHHHTnvvPOyffv2HHXUUbn22mvzhje8YVHHnPtBzA9+8IO57777ct1112XNmjXZtGlTHnnkkT1+3Zo1a2b/+YADDtjrGvD57gcArDxLfVeR1cgV7jHzwAMP5KCDDspP//RPZ+fOnbnkkktm33va056Whx56aK9B+7SnPS1TU1M/8fj3339/nv3sZ2fNmjW58847c8UVVyzp/HO99KUvzac+9ak89NBD2blzZ37/93+/2/cCABhXrnCPmRe+8IV5zWtekw0bNuSwww7LK17xilx99dVJkmc84xl54xvfmBe+8IV5+tOf/rh13Mccc0zWr1+fF7zgBXne8573Y+u4d/m1X/u1vOY1r8kLXvCCrF27Nqecckq3P8srX/nKXHvttTnmmGPyjGc8IyeddFLuu+++bt8PAFaa1XhP6tWoWmujnmFJTU5Otuuvv/5x22+99dY8//nPH8FEq9uDDz6Ygw8+ODt37syb3/zm/MzP/Mzshyrncn4AWI0s11i8Uf6QUVU3tNb2eQs2V7jp6swzz8ztt9+ehx9+OMcff/xeH9oDADBUgpuuPvOZz4x6BABYMq5Isz98aBIAADpaVcE9tPXqQ+G8AABDtmqCe82aNbn33nvF3ZhpreXee+/9sXt5AwAMyapZw7127drs2LEj99xzz6hHYTdr1qzJ2rVrRz0GAEAXqya4n/jEJ+aoo44a9RgAwF64JzVDtWqWlAAAwCismivcAMDq4hZ+jIuxDu6qekKS9yV5WpLrW2v/YcQjAQDAgiz7kpKq2lJVd1fVzbttP7WqvllVt1XVhTObX5VkbZIfJdmx3LMCAMBijWIN99Ykp87dUFUHJLk4yWlJNiQ5o6o2JFmf5NrW2j9P8j8v85wAALBoyx7crbWrk/xwt80nJLmttfad1tqjSS7P9NXtHUnum9ln5/JNCQAAS2Nc1nA/J8n35rzekeTEJL+T5CNV9Q+TfGVvX1xVm5JsSpIjjjii45gAwC4+lAjzMy7BvUettYeSnD2P/TYn2Zwkk5OTHiUJAMDYGJfgvjPJ4XNer53ZBgAsEVekYTTG5cE325M8t6qOqqqDkrw+yZUjngkAABZtFLcFvCzJV5Osr6odVXV2a+2xJO9I8oUktyb5ZGvtluWeDQAAltqyLylprZ2xl+1XJblqf49bVRuTbFy3bt3+HgIAAJbcuCwpWbTW2rbW2qaJiYlRjwIAALPG5UOTAMAcPuAIwzGYK9wAADCOBDcAAHQkuAEAoKPBBHdVbayqzVNTU6MeBQAAZg3mQ5OttW1Jtk1OTr5l1LMAMP6W+kOJl571oiU9HjAcg7nCDQAA40hwAwBAR4IbAAA6GswabgCGayU8BGYlzAiMhivcAADQ0WCC220BAQAYR4MJ7tbattbapomJiVGPAgAAswYT3AAAMI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeDCW734QYAYBwNJrjdhxsAgHE0mOAGAIBxdOCoBwBgeM7eun3UIwCMDcENsAItddBeetaLlvR4APwtwQ2AK9IAHVnDDQAAHQluAADoSHADAEBHghsAADoaTHB70iQAAONoMMHtSZMAAIyjwQQ3AACMI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQ0YGjHgBg6M7eun3UIwAwQq5wAwBAR4IbAAA6Gkxwe7Q7AADjaDDB7dHuAACMo8EENwAAjCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JFHuwPsxqPYAVhKghtY8QQyAOPMkhIAAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBhPcVbWxqjZPTU2NehQAAJg1mOBurW1rrW2amJgY9SgAADBrMMENAADjSHADAEBHghsAADoS3AAA0JHgBgCAjg4c9QDAeDt76/YlPd6lZ71oSY8HAOPOFW4AAOjIFW5gWS31FXMAGHeucAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADryaHcYGI9OB4DxMpgr3FW1sao2T01NjXoUAACYNZjgbq1ta61tmpiYGPUoAAAwazDBDQAA40hwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoKMDRz0ArHZnb90+6hEAgI5c4QYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADo6MBRDwArydlbt496BABghXGFGwAAOhrr4K6ql1bVNVV1SVW9dNTzAADAQi17cFfVlqq6u6pu3m37qVX1zaq6raounNnckvxVkjVJdiz3rAAAsFijuMK9NcmpczdU1QFJLk5yWpINSc6oqg1JrmmtnZbkgiTvXeY5AQBg0ZY9uFtrVyf54W6bT0hyW2vtO621R5NcnuRVrbWdM+/fl+RJeztmVW2qquur6vp77rmny9wAALA/xmUN93OSfG/O6x1JnlNVr66qjyX5/SQf3dsXt9Y2t9YmW2uTz3zmMzuPCgAA8zfWtwVsrX06yadHPQcAAOyvcbnCfWeSw+e8XjuzDQAAVrRxCe7tSZ5bVUdV1UFJXp/kyhHPBAAAizaK2wJeluSrSdZX1Y6qOru19liSdyT5QpJbk3yytXbLcs8GAABLbdnXcLfWztjL9quSXLW/x62qjUk2rlu3bn8PwQB5FDsAMGrjsqRk0Vpr21prmyYmJkY9CgAAzBpMcAMAwDgS3AAA0JHgBgCAjgQ3AAB0NJjgrqqNVbV5ampq1KMAAMCswQS3u5QAADCOBhPcAAAwjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6Ggwwe22gAAAjKPBBLfbAgIAMI4GE9wAADCOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHgwlu9+EGAGAcDSa43YcbAIBxdOCoB4C5zt66fdQjAAAsqcFc4QYAgHEkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoazG0Bq2pjko3r1q0b9Sirhlv4AQDs22CucHvwDQAA42gwwQ0AAONIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHgwnuqtpYVZunpqZGPQoAAMwaTHC31ra11jZNTEyMehQAAJg1mOAGAIBxJLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeDCe6q2lhVm6empkY9CgAAzBpMcLfWtrXWNk1MTIx6FAAAmDWY4AYAgHEkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR/MO7qp6UlW9u6qO7TkQAAAMybyDu7X235O8O8kh/cYBAIBhWeiSkuuS/HyPQQAAYIgOXOD+70ryiar6UZKrknw/SZu7Q2vtoSWaDQAAVryFBvd1M79/OMnv7GWfA/Z/HAAAGJaFBvc/y25XtAEAgL1bUHC31rZ2mmPRqmpjko3r1q0b9SgAADBroVe4kyRVtSHJ8UkOT7KltXZXVa1L8v3W2oNLOeB8tda2Jdk2OTn5llF8/5Xg7K3bRz0CAMCqs6DgrqqnJtmS5PQkP5r5+s8nuSvJ/5HkL5Ocv8QzAgDAirXQ2wJ+MMmLk5yS5OAkNee9q5KcukRzAQDAICx0Scmrk5zbWvtSVe1+N5I7kvzs0owFAADDsNAr3E9Ocu9e3js4yd8sbhwAABiWhQb39iRn7uW905Ncu7hxAABgWBa6pOR/S/LHVfWfkvxhpu/J/YqqOi/Twf0/LPF8AACwoi3oCndr7ZpMf2DySUk+mukPTb43yd9N8rLWmvvOAQDAHAu+D3dr7b8k+YdV9eQkT09yf2vtoSWfDAAABmCha7jneiTT9+J+eIlmAQCAwVlwcFfVK6rq2kwH911JHqmqa6vqHy/5dAAAsMItKLir6q1JtiX5qyTnJnnNzO9/leTKmfcBAIAZC13D/b8m+Vhr7W27bb+kqi5J8u4kH1uSyQAAYAAWuqTk0CSf2ct7/zHJMxY3DgAADMtCg/tLSX5xL+/9YpKrFzcOAAAMyz6XlFTVhjkvP5zk96rq0CSfTXJ3kp9K8k+SnJbkzT2GBACAlWo+a7hvzvQTJXepJG+d+dVmXu/y+SQHLNl0AACwws0nuE/uPgUAAAzUPoO7tfaV5RgEAACGaMGPdt+lqg5MctDu2z3mHQAA/tZCH3wzUVW/W1X/LdNPmnxwD78AAIAZC73CvTXTt//7v5LcluTRpR4IAACGZKHBfUqSt7bWLusxDAAADM1CH3zzl0ms0QYAgHlaaHC/K8l7quqIHsMAAMDQLGhJSWvtqqp6WZLbqur2JPfvYZ8Tlmg2AABY8RYU3FX1gST/S5Lt8aFJAADYp4V+aPLNSd7dWvvXPYYBAIChWega7oeS3NBjEAAAGKKFBvfvJNlUVdVjGAAAGJqFLik5LMmJSb5ZVV/O4z802VprFyzFYAAAMAQLDe7TkzyW5IlJ/tEe3m9JBDcAAMxY6G0Bj+o1yN5U1VOSfCXJRa21P1ru7w8AAIux0DXci1ZVW6rq7qq6ebftp1bVN6vqtqq6cM5bFyT55PJOCQAAS2Oh9+F+2772aa397j522Zrko0k+Pue4ByS5ONPLVHYk2V5VVyZ5TpJvJFmzkDkBAGBcLHQN90d/wntt5vefGNyttaur6sjdNp+Q5LbW2neSpKouT/KqJE9N8pQkG5I8XFVXtdZ27n7MqtqUZFOSHHGEp84DADA+FrqG+3FLUKrqkCS/nOmlH2fs5xzPSfK9Oa93JDmxtfaOme9xVpIf7Cm2Z+banGRzkkxOTrY97QMAAKOw0Cvcj9Nauz/JH1TVRJKPJXnpYo+5h++xdamPCQAAy2EpPzT53SST+/m1dyY5fM7rtTPbAABgRVuS4K6qZyf5F5mO7v2xPclzq+qoqjooyeuTXLkUswEAwCgt9C4l9+RvPxy5y0FJDk7ySJJXz+MYl2V62clhVbUjyb9srV1aVe9I8oUkByTZ0lq7ZSGzAQDAOFroGu6L8/jgfiTTH3L8fGvt3n0doLW2xw9WttauSnLVAueZVVUbk2xct27d/h4CAACW3ELvUnJRpzkWrbW2Lcm2ycnJt4x6FgAA2GWfwV1Vf7KA47XW2imLmAcAAAZlPle497lMJMmzk7w4j19uAgAAq9o+g7u19pq9vVdVR2T6gTf/Y5IfJPnQ0o0GAAAr3349+Kaq1iX5jST/NMndM//8sdbaw0s4GwAArHgLug93VR1dVZ9IcmuSk5Ocm+Tvtdb+3ahju6o2VtXmqampUY4BAAA/Zl7BXVXHV9Wnk9yU5OeTvDnJc1trl7TWHu054Hy11ra11jZNTEyMehQAAJg1n7uUfC7Jy5N8PcnrW2t/2H0qAAAYiPms4f7lmd/XJrm4qi7+STu31n5q0VMBAMBAzCe439t9CgAAGKj53BZQcAMAwH5a0F1KAACAhRlMcLstIAAA42gwwe22gAAAjKPBBDcAAIwjwQ0AAB0JbgAA6Gg+9+EGVrF3fv89S3q8jzzr/Ut6PAAYd65wAwBAR4IbAAA6GsySkqramGTjunXrRj3Kkjl76/ZRjwAAwCINJrhba9uSbJucnHzLqGeBUVrqNdcAwOJYUgIAAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdDSY+3AP8cE3467H/Z4/8qz3L/kxYYiW+u+fv3sA/QzmCndrbVtrbdPExMSoRwEAgFmDucINe+Iq4OrgPAMwzgZzhRsAAMaR4AYAgI4sKYER6/HhUwBgfAhuWABxDAAslCUlAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQ3mLiVVtTHJxnXr1o16FACWWI87BHmiKLBcBhPcrbVtSbZNTk6+ZdSzADD+ljriBTywN4MJbgBgZfNDEEMluIFl5eFBAKw2gpuxIsYYIv+7Bljd3KUEAAA6EtwAANCRJSUA+LDaKuE8w2gIbgAYQ9b+w3BYUgIAAB25wg2wG1cWgeVimc/qILgBgP2yGn84XY1/ZhbPkhIAAOhIcAMAQEeCGwAAOhpMcFfVxqraPDU1NepRAABg1mA+NNla25Zk2+Tk5FtGPQvAaueDZQB/azDBDQCj5IcMYG8ENwAwSH4IYlwMZg03AACMI8ENAAAdCW4AAOhIcAMAQEc+NAkAwLJZ+g+zfmGJj7f0BDcAwED0uDPLR571/iU/5mpjSQkAAHQkuAEAoCNLSlYRDwAAAFh+rnADAEBHrnADALBX/gv54rnCDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgYT3FW1sao2T01NjXoUAACYNZjgbq1ta61tmpiYGPUoAAAwazDBDQAA40hwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdHTgqAf4Sarq+UnOTXJYkv/cWvv3Ix5pWb3z++8Z9QgAACzSsl/hrqotVXV3Vd282/ZTq+qbVXVbVV2YJK21W1tr5yR5bZKXLPesAACwWKNYUrI1yalzN1TVAUkuTnJakg1JzqiqDTPvvTLJ/53kquUdEwAAFm/Zg7u1dnWSH+62+YQkt7XWvtNaezTJ5UleNbP/la2105K8cXknBQCAxRuXNdzPSfK9Oa93JDmxql6a5NVJnpSfcIW7qjYl2ZQkRxxxRL8pAQBggcYluPeotfblJF+ex36bk2xOksnJydZ3KgAAmL9xuS3gnUkOn/N67cw2AABY0cYluLcneW5VHVVVByV5fZIrRzwTAAAs2ihuC3hZkq8mWV9VO6rq7NbaY0nekeQLSW5N8snW2i3LPRsAACy1ZV/D3Vo7Yy/br8oibv1XVRuTbFy3bt3+HgIAAJbcuCwpWbTW2rbW2qaJiYlRjwIAALMGE9wAADCOBDcAAHQkuAEAoCPBDQAAHQluAADoaDDBXVUbq2rz1NTUqEcBAIBZgwlutwUEAGAcDSa4AQBgHAluAADoSHADAEBHghsAADoS3AAA0NFggtttAQEAGEeDCW63BQQAYBwNJrgBAGAcCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBhPc7sMNAMA4Gkxwuw83AADjaDDBDQAA40hwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgo8EEtwffAAAwjgYT3B58AwDAOBpMcAMAwDgS3AAA0JHgBgCAjgQ3AAB0JLgBAKCjA0c9wFCcvXX7kh/znUt+RAAAlpsr3AAA0JHgBgCAjgQ3AAB0JLgBAKCjwQR3VW2sqs1TU1OjHgUAAGYNJrhba9taa5smJiZGPQoAAMwaTHADAMA4EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoKPBBHdVbayqzVNTU6MeBQAAZg0muFtr21prmyYmJkY9CgAAzBpMcAMAwDgS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBhPcVbWxqjZPTU2NehQAAJg1mOBurW1rrW2amJgY9SgAADBrMMENAADjSHADAEBHghsAADoS3AAA0JHgBgCAjgQ3AAB0JLgBAKAjwQ0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAdCW4AAOhIcAMAQEeCGwAAOhLcAADQkeAGAICOBDcAAHQkuAEAoCPBDQAAHQluAADoSHADAEBHB456gKF45/ffM+oRAAAYQ65wAwBAR4IbAAA6EtwAANDR2K/hrqpfSfKPkzwtyaWttS+OeCQAAJi3kVzhrqotVXV3Vd282/ZTq+qbVXVbVV2YJK21z7bW3pLknCSvG8W8AACwv0a1pGRrklPnbqiqA5JcnOS0JBuSnFFVG+bs8p6Z9wEAYMUYSXC31q5O8sPdNp+Q5LbW2ndaa48muTzJq2rav0nyudba/7PcswIAwGKM04cmn5Pke3Ne75jZ9s4kL0tyelWds6cvrKpNVXV9VV1/zz339J8UAADmaew/NNla+3CSD+9jn81JNifJ5ORkW465AABgPsbpCvedSQ6f83rtzDYAAFixxim4tyd5blUdVVUHJXl9kitHPBMAACzKqG4LeFmSryZZX1U7qurs1tpjSd6R5AtJbk3yydbaLaOYDwAAlspI1nC31s7Yy/arkly1P8esqo1JNq5bt24xowEAwJIapyUli9Ja29Za2zQxMTHqUQAAYNZgghsAAMaR4AYAgI4ENwAAdCS4AQCgo8EEd1VtrKrNU1NTox4FAABmDSa43aUEAIBxNJjgBgCAcSS4AQCgI8ENAAAdCW4AAOioWmujnmFJVdU9Se4Ywbc+LMkPRvB9WV7O8+rgPK8OzvPwOcerwyjP88+21p65r50GF9yjUlXXt9YmRz0HfTnPq4PzvDo4z8PnHK8OK+E8W1ICAAAdCW4AAOhIcC+dzaMegGXhPK8OzvPq4DwPn3O8Ooz9ebaGGwAAOnKFGwAAOhLcC1RVp1bVN6vqtqpNaqW5AAAHQklEQVS6cA/vV1V9eOb9m6rq50cxJ4szj/P8xpnz+/Wquraqjh3FnCzOvs7znP1eVFWPVdXpyzkfizefc1xVL62qG6vqlqr6ynLPyOLN4/+zJ6pqW1V9beY8v2kUc7L/qmpLVd1dVTfv5f2x7i/BvQBVdUCSi5OclmRDkjOqasNuu52W5LkzvzYl+ffLOiSLNs/z/N0kv9hae2GS92UFrB/jx83zPO/a798k+eLyTshizeccV9UhSX43yStba0cnec2yD8qizPPv8tuTfKO1dmySlyb5t1V10LIOymJtTXLqT3h/rPtLcC/MCUlua619p7X2aJLLk7xqt31eleTjbdqfJTmkqp693IOyKPs8z621a1tr9828/LMka5d5RhZvPn+fk+SdSf5jkruXcziWxHzO8RuSfLq19pdJ0lpznlee+ZznluTgqqokT03ywySPLe+YLEZr7epMn7e9Gev+EtwL85wk35vzesfMtoXuw3hb6Dk8O8nnuk5ED/s8z1X1nCT/JGN2pYR5m8/f5b+f5OlV9eWquqGqzly26Vgq8znPH03y/CT/X5KvJzm3tbZzecZjmYx1fx046gFgJauqkzMd3P9g1LPQxb9LckFrbef0hTEG6MAkxyc5JcmTk3y1qv6stfZfRzsWS+yXk9yY5JeS/L0kf1xV17TWHhjtWKwWgnth7kxy+JzXa2e2LXQfxtu8zmFVHZPk95Kc1lq7d5lmY+nM5zxPJrl8JrYPS/KKqnqstfbZ5RmRRZrPOd6R5N7W2l8n+euqujrJsUkE98oxn/P8piT/Z5u+F/JtVfXdJM9L8ufLMyLLYKz7y5KShdme5LlVddTMhy1en+TK3fa5MsmZM5+WPSnJVGvtvy33oCzKPs9zVR2R5NNJ/idXwlasfZ7n1tpRrbUjW2tHJvlUkreJ7RVlPv+ffUWSf1BVB1bV30lyYpJbl3lOFmc+5/kvM/1fMVJVz0qyPsl3lnVKehvr/nKFewFaa49V1TuSfCHJAUm2tNZuqapzZt6/JMlVSV6R5LYkD2X6p2pWkHme5/89yaFJfnfm6udjrbXJUc3Mws3zPLOCzecct9ZurarPJ7kpyc4kv9da2+NtxxhP8/y7/L4kW6vq60kq00vFfjCyoVmwqros03eYOayqdiT5l0memKyM/vKkSQAA6MiSEgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4EN8AqUFWfqqovL2D/rVV1/Tz2azO3ZNv1+glVdXFVfX/mvYuq6oSqumj/JgdY+dyHG4DF+IUk353z+tVJ3pbk7CTfyPSTHH8l0/fMvWi5hwMYB4IbYAWoqgOSHNBae3TUs8zVWvuz3TY9L8l9rbUtuzbMPBwKYNWypARgDO1a0lFVv1JVtyR5JMmJVXVEVV1eVT+sqoeq6gtVtX63rz28qq6qqoer6vaqevMejr+2qj5ZVXfP7PftqnrfHvb7R1V1U1X9dVX9aVUdvdv7s0tKZpasvC/J02e2t6o6K8lH5uzbFrK0BWAIXOEGGF9HJvmtJL+Z5K4kdyT50yT3Jjkn048vvjDJf6qqv99ae7imLydfkeSwTC/reCTJe5M8I8m35hz740menGRTkvuT/N1MX52e64gkv53kXyV5OMkHkvxBVb2w7fkxxW9L8s+TnJ7k1Jlt303yb5P8i0wvP0mSBxb47wFgRRPcAOPr0CQva63dmCQzV6CfkuS41toPZ7b9lyS3J/lnSS5OclqSn0tyUmvtupl9bkjy7fx4cJ+Q5IzW2raZ11/ew/d/RpKXtNa+NXOcJyT5TJL1Sf7f3XdurX2jqnYkeWzuUpOqun3m/d2XnwCsCpaUAIyvO3fF9oyXJfnjJA9U1YFVdWCSB5PckGRyZp8Tknx/V2wnSWvtjpl95roxyb+uqrOq6oi9fP/bd8X2jG/M/L52//44AKuT4AYYX9/f7fVhSV6X5Ee7/To5yeEz+/x0krv3cKzdt70uyfVJPpTkjqq6sapO2W2f+3d7vesDm2vm+wcAwJISgHG2+zrpHya5MtMfTNzdgzO/35Xkp/bw/k9leh329IFbuzPJWTPLRE7I9C37rqyqI1pr9y5ybgDmcIUbYOX4z0mOTnJLa+363X59c2af7UmeVVUn7vqimSUjP7+nA7bWds6srX5vkr+T5Gc7zP3ozByujAOrkivcACvHB5P80yR/UlUfSXJnkmcl+cUkf9pauyzJVUm+luQPq+qCJP890zE9u6SkqiaSfCHTdyr5r0melOm7iNyV5NYOc+/6gOW5VfUnSR6Y8wMCwOC5wg2wQrTWfpDkpEwH7IeSfDHTtw2cSHLTzD4tySsz/QHHLTP7fTTJV+cc6pEkX09ybqaXqPyHTN9i8OWttYez9K7J9O0Fz01yXZKPdfgeAGOr9nwrVQAAYCm4wg0AAB0JbgAA6EhwAwBAR4IbAAA6EtwAANCR4AYAgI4ENwAAdCS4AQCgI8ENAAAd/f8o6C7LNuJgCQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x2b10bb93b080>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = plt.figure(figsize=(12,10))\n",
+    "zall,zbinedges,zbinpatches = plt.hist(df['redshift'],bins=30,range=(0.,1.),alpha=0.7,label='All')\n",
+    "sztrain, szbinedgestrain, szpatchestrain = plt.hist(flat_train_sz,bins=30,range=(0.,1.),alpha=0.7,label='flat training')\n",
+    "plt.yscale('log')\n",
+    "plt.xlabel('redshift',fontsize=15)\n",
+    "plt.ylabel('Number',fontsize=15)\n",
+    "plt.legend(loc='upper left',fontsize=11)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looks as expected, so let's write out the subset that have flat_training_flag set to True to their own HDF5 file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_flat_train = df[df['flat_training_flag']==True]\n",
+    "outfile_protodc2_flat_training = \"protodc2_v5_ugrizy_witherrs_flat_training.h5\"\n",
+    "#comment out for now so I don't accidentally overwrite\n",
+    "#df_flat_train.to_hdf(outfile_protodc2_flat_training, 'df_flat_train')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "desc-python",
+   "language": "python",
+   "name": "desc-python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A simple notebook for selecting a random subset of objects that is "flat" in apparent magnitude up to some limit as a training sample.  All this notebook does is make  histogram of the i-band magnitude counts, use the inverse of the binned count as a weight in whether or not to select each galaxy as a training galaxy or not.  Result is an hdf5 file with one extra column indicating which subset are "flat_training" galaxies (I will copy the file to NERSC DC2 folder).

This is our initial idea for some incompleteness in a training set.  As the magnitude selection is random a "re-weighting" method a la Lima et al should be able to recover the true population, but just using the sample as-is should lead to a biased photo-z estimate.
